### PR TITLE
Add null check on function handler

### DIFF
--- a/src/metrics.js
+++ b/src/metrics.js
@@ -55,7 +55,8 @@ function sendLibraryTemplate(downloadUrl, tabId, done)
 		var template = JSON.parse(response)
 
 		chrome.tabs.sendMessage(tabId, { Name: template.Name, Description: template.Description, DownloadUrl: downloadUrl})
-		done()
+		if (done)
+		    done();
 	})
 }
 


### PR DESCRIPTION
No handler function was being passed to the `sendLibraryTemplate`
function, so it was getting an unhandled error. Fixes #33.