### PR TITLE
Add ability to view deployment process of a release

### DIFF
--- a/SpecRunner.html
+++ b/SpecRunner.html
@@ -18,15 +18,19 @@
   <script src="src/3.0/background/step-template-update.js"></script>
   <script src="src/3.0/background/clone-step-handler.js"></script>
   <script src="src/3.0/background/edit-step-as-json-handler.js"></script>
+  <script src="src/3.0/background/template-loader.js"></script>
   <script src="src/3.0/clone-step.js"></script>
   <script src="src/3.0/edit-step-as-json.js"></script>
+  <script src="src/3.0/view-release-deployment-process.js"></script>
   
   <!-- include spec files here... -->
   <script src="spec/3.0/background/step-template-update.js"></script>
   <script src="spec/3.0/background/clone-step-handler.js"></script>
   <script src="spec/3.0/background/edit-step-as-json-handler.js"></script>
+  <script src="spec/3.0/background/template-loader.js"></script>
   <script src="spec/3.0/clone-step.js"></script>
   <script src="spec/3.0/edit-step-as-json.js"></script>
+  <script src="spec/3.0/view-release-deployment-process.js"></script>
   
   <!-- Wire up ConsoleReporter -->
   <script type="text/javascript" src="spec/SpecRunner.js"></script>

--- a/spec/3.0/background/template-loader.js
+++ b/spec/3.0/background/template-loader.js
@@ -1,0 +1,91 @@
+describe("template-loader", function() {
+  var originalConsoleDebug;
+  var originalConsoleLog;
+
+  beforeEach(function () {
+    originalConsoleDebug = console.debug;
+    originalConsoleLog = console.log;
+    console.debug = function() {};
+    console.log = function() {};
+  });
+
+  afterEach(function() {
+    console.debug = originalConsoleDebug;
+    console.log = originalConsoleLog
+  });
+
+  describe("receiveMessage", function() {
+    it("does nothing if its not a 'get-template' message", function() {
+      
+      var request = { message: 'some-other-message-type' };
+      var sender = {};
+      var called = false;
+      var sendResponse = function() {
+        called = true;
+      }
+      pygmy3_0.templateLoader.receiveMessage(request, sender, sendResponse);
+
+      expect(called).toBe(false);
+
+    });
+
+    it("returns the template if its a 'get-template' message for a valid template", function() {
+      var request = { message: 'get-template', properties: { templateName: 'show-release-deployment-plan.html' } };
+      var sender = {};
+      var called = false;
+      var responseMessage = '';
+      var sendResponse = function(message) {
+        called = true;
+        responseMessage = message;
+      }
+      var requestedTemplateName = '';
+      var urlRetriever = function(templateName) {
+        requestedTemplateName = templateName
+        return 'some-random-url';
+      } 
+      var requestedUrl = '';
+      var getJsonResponseHandler = function(url, done) {
+        requestedUrl = url;
+        done(200, "this is some html");
+      }
+      pygmy3_0.templateLoader.receiveMessage(request, sender, sendResponse, urlRetriever, getJsonResponseHandler);
+
+      expect(called).toBe(true);
+      expect(requestedTemplateName).toBe('templates/show-release-deployment-plan.html')
+      expect(requestedUrl).toBe('some-random-url');
+      expect(responseMessage.properties.status).toBe('success');
+      expect(responseMessage.properties.templateName).toBe('show-release-deployment-plan.html');
+      expect(responseMessage.properties.template).toBe('this is some html');
+    });
+
+    it("returns an error if its a 'get-template' message for an invalid template", function() {
+      var request = { message: 'get-template', properties: { templateName: 'a-template-that-does-not-exist.html' } };
+      var sender = {};
+      var called = false;
+      var responseMessage = '';
+      var sendResponse = function(message) {
+        called = true;
+        responseMessage = message;
+      }
+      var requestedTemplateName = '';
+      var urlRetriever = function(templateName) {
+        requestedTemplateName = templateName
+        return 'some-random-url';
+      } 
+      var requestedUrl = '';
+      var getJsonResponseHandler = function(url, done) {
+        requestedUrl = url;
+        done(0, null);
+      }
+      pygmy3_0.templateLoader.receiveMessage(request, sender, sendResponse, urlRetriever, getJsonResponseHandler);
+
+      expect(called).toBe(true);
+      expect(requestedTemplateName).toBe('templates/a-template-that-does-not-exist.html')
+      expect(requestedUrl).toBe('some-random-url');
+      expect(responseMessage.properties.status).toBe('failure');
+      expect(responseMessage.properties.templateName).toBe('a-template-that-does-not-exist.html');
+      expect(responseMessage.properties.template).toBe(undefined);
+      expect(responseMessage.properties.errorMessage).toBe("Failed to load template - status code 0");
+    });
+  });
+});

--- a/spec/3.0/view-release-deployment-process.js
+++ b/spec/3.0/view-release-deployment-process.js
@@ -1,0 +1,156 @@
+describe("view-release-deployment-process", function() {
+  var originalConsoleDebug;
+  var originalConsoleLog;
+
+  beforeEach(function () {
+    originalConsoleDebug = console.debug;
+    originalConsoleLog = console.log;
+    console.debug = function() {};
+    console.log = function() {};
+  });
+
+  afterEach(function() {
+    console.debug = originalConsoleDebug;
+    console.log = originalConsoleLog
+  });
+
+
+  function removeElement(id) {
+    var element = document.getElementById(id);
+    if (element) {
+      if (element.remove)
+        element.remove();
+      else
+        element.parentNode.removeChild(element);
+    }
+  }
+
+  describe("receiveMessage", function() {
+    var showLink;
+    beforeEach(function () {
+      showLink = document.createElement('a');
+      showLink.id = 'bluefin-showreleasedeploymentprocess-button';
+      document.body.appendChild(showLink);
+    });
+
+    afterEach(function() {
+      removeElement('bluefin-showreleasedeploymentprocess-handler');
+      removeElement('bluefin-showreleasedeploymentprocess-button');
+    });
+
+    it("should do nothing if its not a 'get-template' message", function() {
+      var message = { 'message': 'a-different-message' };
+      pygmy3_0.viewReleaseDeploymentProcess.receiveMessage(message);
+
+      var script = document.getElementById('bluefin-showreleasedeploymentprocess-handler');
+      expect(script).toBe(null);
+    });
+
+    it("should do nothing if its not the 'show-release-deployment-plan.html' template", function() {
+      var message = { 'message': 'get-template-response', 'properties': { 'templateName' : 'a-different-template.html', 'template': '<div>hello</div>' }};
+      pygmy3_0.viewReleaseDeploymentProcess.receiveMessage(message);
+
+      var script = document.getElementById('bluefin-showreleasedeploymentprocess-handler');
+      expect(script).toBe(null);
+    });
+
+    it("should should add a new script element", function() {
+      var template = '<div>hello</div>';
+      var message = { 'message': 'get-template-response', 'properties': { 'templateName' : 'show-release-deployment-plan.html', 'template': template }};
+      pygmy3_0.viewReleaseDeploymentProcess.receiveMessage(message);
+
+      var script = document.getElementById('bluefin-showreleasedeploymentprocess-handler');
+      expect(script).not.toBe(null);
+      expect(script.type).toBe('text/javascript');
+      expect(script.text).not.toContain("template: '#{template}'");
+      expect(script.text).toContain("template: '" + template + "',");
+    });
+  });
+
+  describe("checkIfWeAreOnReleasePage", function() {
+    it("should add the link if we are on the releases page", function() {
+      var called = false;
+      var handler = function() { called = true; };
+      var locationFn = function() { return "#/projects/my-fancy-project/releases/0.1.21" };
+
+      
+      pygmy3_0.viewReleaseDeploymentProcess.checkIfWeAreOnReleasePage(handler, locationFn);
+
+      expect(called).toBe(true);
+    });
+
+    it("should not add the link if we are on the deployments page", function() {
+      var called = false;
+      var handler = function() { called = true; }
+      var locationFn = function() { return "#/projects/Projects-411/releases/0.1.21/deployments/Deployments-5694" };
+      
+      pygmy3_0.viewReleaseDeploymentProcess.checkIfWeAreOnReleasePage(handler, locationFn);
+
+      expect(called).toBe(false);
+    });
+
+    it("should not add the link if we are on the create release page", function() {
+      var called = false;
+      var handler = function() { called = true; }
+      var locationFn = function() { return "#/projects/Projects-411/releases/create" };
+      
+      pygmy3_0.viewReleaseDeploymentProcess.checkIfWeAreOnReleasePage(handler, locationFn);
+
+      expect(called).toBe(false);
+    });
+  });
+
+  describe("addDeploymentProcessLink", function() {
+    var variablesHeading;
+    beforeEach(function () {
+      var s = '<h3 class="margin-top-20">Variables</h3>\n\n        <p class="subtle"></p>\n\n        <!-- ngIf: viewShowVariables -->';
+      var div = document.createElement('div');
+      div.innerHTML = s;
+      div.id = 'div-for-testing-view-release-deployment-process';
+      document.body.appendChild(div);
+    });
+
+
+    afterEach(function() {
+      removeElement('variablesHeading');
+      removeElement('div-for-testing-view-release-deployment-process');
+    });
+
+
+    it("should add a heading", function() {
+      var called = false;
+      var sendMessageHandler = function(message, handler) { 
+        called = true; 
+        expect(handler).toBe(receiveMessageHandler);  
+      };
+      var receiveMessageHandler = function() {};
+
+      pygmy3_0.viewReleaseDeploymentProcess.addDeploymentProcessLink(sendMessageHandler, receiveMessageHandler);
+
+      expect(document.getElementById('bluefin-showreleasedeploymentprocess-heading')).not.toBe(null);
+      expect(document.getElementById('bluefin-showreleasedeploymentprocess-heading').innerText).toBe("Deployment Process");
+      expect(document.getElementById('bluefin-showreleasedeploymentprocess-description')).not.toBe(null);
+      expect(document.getElementById('bluefin-showreleasedeploymentprocess-description').innerText).toBe("When this release was created, a snapshot of the project deployment process was taken. Show »");
+      expect(document.getElementById('bluefin-showreleasedeploymentprocess-button')).not.toBe(null);
+      expect(document.getElementById('bluefin-showreleasedeploymentprocess-button').innerText).toBe("Show »");
+    });
+
+    it("should not add more than once", function() {
+      var called = false;
+      var sendMessageHandler = function(message, handler) { 
+        called = true; 
+        expect(handler).toBe(receiveMessageHandler);  
+      };
+      var receiveMessageHandler = function() {};
+
+      pygmy3_0.viewReleaseDeploymentProcess.addDeploymentProcessLink(sendMessageHandler, receiveMessageHandler);
+      expect(document.querySelectorAll('h3').length).toBe(2); //"Variables" + "Deployment Process";
+      pygmy3_0.viewReleaseDeploymentProcess.addDeploymentProcessLink(sendMessageHandler, receiveMessageHandler);
+      expect(document.querySelectorAll('h3').length).toBe(2);
+    });
+  });
+
+  describe("angularShowModalDialog", function() {
+    //unfortunately, I dont there there is a way of testing this, given the dependency on AngularJS & the Octopus AngularJS app
+  });
+});

--- a/src/3.0/background/pygmy.js
+++ b/src/3.0/background/pygmy.js
@@ -6,6 +6,7 @@ var pygmy3_0 = (function() {
 		pygmy3_0.stepTemplateUpdate.setup();
 		pygmy3_0.cloneStepHandler.setup();
 		pygmy3_0.editStepAsJsonHandler.setup();
+		pygmy3_0.templateLoader.setup();
 	}
 	
 	return {

--- a/src/3.0/background/template-loader.js
+++ b/src/3.0/background/template-loader.js
@@ -1,0 +1,60 @@
+pygmy3_0.templateLoader = (function() {
+
+	function receiveMessage(request, sender, sendResponse, urlRetriever, getJsonResponseHandler)	{
+		if (request.message == 'get-template')
+		{
+			console.log("Loading template 'templates/" + request.properties.templateName + "'");
+			
+			var urlRetriever = urlRetriever || chrome.extension.getURL
+			var url = urlRetriever('templates/' + request.properties.templateName);
+			console.log("Extension relative url is '" + url + "'");
+
+			getJsonResponseHandler = getJsonResponseHandler || getJsonResponse
+
+			getJsonResponseHandler(url, function(status, response){
+				console.log("Loaded content from url '" + url + "' with status '" + status + "' and response '" + response + "'");
+				var msg;
+				if (status == 200) {
+					msg = { 
+						message: 'get-template-response',
+						properties: { 
+							status: 'success',
+							templateName: request.properties.templateName, 
+							template: response.replace(/(\r\n|\n|\r)/gm,"")
+						}
+					};
+				} else {
+					msg = { 
+						message: 'get-template-response',
+						properties: {
+							status: 'failure',
+							templateName: request.properties.templateName, 
+							errorMessage: "Failed to load template - status code " + status
+						}
+					};
+				}
+				console.log("Sending response message");
+            	sendResponse(msg);
+			});
+
+			return true; // see https://developer.chrome.com/extensions/runtime#event-onMessageExternal
+		}
+	}
+
+	function getJsonResponse(url, handler) {
+		nanoajax.ajax(url, function(status, response){
+			console.debug("Received " + status + " response from " + url);
+			console.debug(response);
+			handler(status, response);
+		});
+	}
+
+	function setup() {
+		chrome.runtime.onMessage.addListener(receiveMessage);
+	}
+
+	return {
+		setup: setup,
+		receiveMessage: receiveMessage
+	}
+})();

--- a/src/3.0/pygmy.js
+++ b/src/3.0/pygmy.js
@@ -26,6 +26,7 @@ var pygmy3_0 = (function() {
 		if(options.updateAllTemplate) this.stepTemplateUpdater.observe(content);
 		if(options.cloneStep) this.cloneStep.observe(content);
 		if(options.editStepAsJson) this.editStepAsJson.observe(content);
+		if(options.viewReleaseDeploymentProcess) this.viewReleaseDeploymentProcess.observe(content);
 	}
 
 	return {

--- a/src/3.0/view-release-deployment-process.js
+++ b/src/3.0/view-release-deployment-process.js
@@ -1,0 +1,168 @@
+pygmy3_0.viewReleaseDeploymentProcess = (function() {
+
+	function receiveMessage(response) {
+        if (response.message == 'get-template-response' && response.properties.templateName == 'show-release-deployment-plan.html') {
+            console.debug("  - got template 'show-release-deployment-plan.html'");
+			console.debug("  - adding handler");
+	        var showDeploymentProcessHandlerScript = document.createElement("script");
+	        showDeploymentProcessHandlerScript.id = 'bluefin-showreleasedeploymentprocess-handler';
+	        showDeploymentProcessHandlerScript.type = 'text/javascript';
+	        var functionAsText = angularShowModalDialog.toString()
+	        functionAsText = functionAsText.replace("#{template}", response.properties.template);
+	        showDeploymentProcessHandlerScript.text = functionAsText.slice(functionAsText.indexOf("{") + 1, functionAsText.lastIndexOf("}"));
+	        document.body.appendChild(showDeploymentProcessHandlerScript);
+        }
+	}
+
+    function angularShowModalDialog(sendMessageHandler) {
+    	var button = document.getElementById('bluefin-showreleasedeploymentprocess-button'); 
+    	button.onClick = button.onclick = function() { 
+            var element = angular.element("#content-wrapper");
+            var modal = element.injector().get('$modal');
+			var modalInstance = modal.open({
+                backdrop: "static",
+                keyboard: !0,
+                size: 'md',
+                template: '#{template}',
+                controller: function ($scope, $routeParams, busy, pageTitle, octopusRepository, $route, pluginRegistry, octoDialog, $modal, $location, unsavedChanges, $modalInstance) {
+			        var isLoading = $scope.isLoading = busy.create();
+			        var isSaving = $scope.isSaving = busy.create();
+			        $scope.project = null;
+			        $scope.close = function () { $modalInstance.close(); };
+			        $scope.actionClass = function(action) {
+			            return action.ActionType.replace(".", "").toLowerCase()
+			        },
+			        $scope.canHaveChildren = function(step) {
+			            var action = pluginRegistry.getDeploymentAction(step.Actions[0].ActionType);
+			            return action.canHaveChildren
+			        };
+			        $scope.releaseVersion = $routeParams.version;
+			        var projectId = $routeParams.id;
+			        var version = $routeParams.version;
+			        var getTags = function(allOptions, selectedOptions) {
+			            if (0 === allOptions.length)
+			                return "";
+			            var result = [];
+			            return _.each(selectedOptions, function(e) {
+			                allOptions.indexOf(e.Id) >= 0 && result.push(e.Name)
+			            }),
+			            result.join(",")
+			        };
+
+					//mock out channels for pre-3.2
+					var getChannels = octopusRepository.Projects.getChannels || function (project) {
+						return Octopus.Client.PromiseWrapper(function(resolve, reject) {
+							resolve(null);
+						});
+					};
+
+			        isLoading.promise(octopusRepository.Projects.get(projectId).then(function(project) {
+			            isLoading.promise(octopusRepository.Lifecycles.get(project.LifecycleId).then(function(lifecycleDefinition) {
+			                isLoading.promise(octopusRepository.Lifecycles.preview(lifecycleDefinition).then(function(lifecycle) {
+			                    isLoading.promise(octopusRepository.Environments.all().then(function(environments) {
+			                        isLoading.promise(getChannels(project).then(function(channels) {
+			                            isLoading.promise(octopusRepository.Projects.getReleaseByVersion(project, version).then(function(release) {
+			                            	isLoading.promise(octopusRepository.DeploymentProcesses.get(release.ProjectDeploymentProcessSnapshotId).then(function(deploymentProcess) {
+				                                return $scope.project = project,
+				                                $scope.lifecycle = lifecycle,
+				                                $scope.environments = environments,
+				                                $scope.channels = channels,
+				                                $scope.deploymentProcess = deploymentProcess,
+				                                $scope.builtInFeedPackageActions = _.filter(_.flatten(_.map(deploymentProcess.Steps, function(s) {
+				                                    return s.Actions
+				                                })), function(a) {
+				                                    return "feeds-builtin" === a.Properties["Octopus.Action.Package.NuGetFeedId"]
+				                                }),
+				                                _.each(deploymentProcess.Steps, function(s) {
+				                                    _.each(s.Actions, function(a) {
+				                                        a.environments = getTags(a.Environments, environments);
+				                                        if (a.channels)
+				                                        	a.channels = getTags(a.Channels, channels.Items)
+				                                    })
+				                                })
+			                            	}))
+			                            }))
+			                        }))
+			                    }))
+			                }))
+			            }))
+			        }));
+			    },
+                dialogClass: "modal"
+            });
+		}
+    }
+
+    function addDeploymentProcessLink(sendMessageHandler, receiveMessageHandler) {
+        if (document.getElementById('bluefin-showreleasedeploymentprocess-button'))
+    		return;
+
+        console.log("Loading Blue fin feature 'show release deployment process'");
+
+    	var headings = document.querySelectorAll('h3');
+    	var variablesHeading;
+    	for(var i=0; i < headings.length; i++ ) {
+    		if (headings[i].innerText === 'Variables') {
+    			variablesHeading = headings[i];
+    		}
+    	}
+		var variablesNote = variablesHeading.nextSibling.nextSibling;
+
+		console.debug("  - adding new heading");
+
+        var newHeading = document.createElement('h3')
+        newHeading.id = 'bluefin-showreleasedeploymentprocess-heading';
+        newHeading.className = 'margin-top-20';
+        newHeading.innerText = "Deployment Process";
+		variablesNote.parentNode.insertBefore(newHeading, variablesNote.nextSibling.nextSibling.nextSibling);
+
+		console.debug("  - adding new desciption text and 'show' link");
+        var newDescription = document.createElement('p');
+        newDescription.id = 'bluefin-showreleasedeploymentprocess-description';
+        newDescription.className = 'subtle';
+        newDescription.innerText = 'When this release was created, a snapshot of the project deployment process was taken. '
+        var showLink = document.createElement('a');
+        showLink.innerText = 'Show »';
+        showLink.id = 'bluefin-showreleasedeploymentprocess-button'
+        showLink.style.cursor = 'pointer';
+		newDescription.appendChild(showLink);
+		variablesNote.parentNode.insertBefore(newDescription, newHeading.nextSibling);
+
+		console.debug("  - getting template html 'show-release-deployment-plan.html'");
+		sendMessageHandler = sendMessageHandler || chrome.runtime.sendMessage;
+		receiveMessageHandler = receiveMessageHandler || receiveMessage;
+		sendMessageHandler({ message: 'get-template', properties: { templateName: 'show-release-deployment-plan.html' }}, receiveMessageHandler);
+    }
+
+	//separate function for mocking
+    function getPageLocationHash() {
+    	return location.hash;
+    }
+
+    function checkIfWeAreOnReleasePage(handler, getPageLocationHashfn) {
+    	getPageLocationHashfn = getPageLocationHashfn || getPageLocationHash;
+    	hash = getPageLocationHashfn();
+        if (hash.match(/#\/projects\/.*\/releases\/[^\/]*$/i)) {
+        	//cant use string.prototype.endsWith, as its not available under jasmine
+        	//would be nice to fold into the regex above
+        	if (hash.indexOf('/create', hash.length - '/create'.length) == -1) { 
+	        	handler = handler || addDeploymentProcessLink
+	        	handler();
+			}
+    	}
+    }
+
+    function observe(content) {
+		var observer = new MutationObserver(function(targets, observer) { checkIfWeAreOnReleasePage(); });
+        observer.observe(content, { childList: true, subtree: true, attributes: false, characterData: false});
+
+        chrome.runtime.onMessage.addListener(receiveMessage);
+    }
+
+    return {
+        observe: observe,
+        receiveMessage: receiveMessage,
+        checkIfWeAreOnReleasePage: checkIfWeAreOnReleasePage,
+        addDeploymentProcessLink: addDeploymentProcessLink
+    };
+})();

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -19,6 +19,7 @@
       "3.0/step-template-updater.js",
       "3.0/clone-step.js",
       "3.0/edit-step-as-json.js",
+      "3.0/view-release-deployment-process.js",
       "octopygmy.js",
       "dashboard-collapser.js",
       "environment-collapser.js",
@@ -45,11 +46,15 @@
       "3.0/background/step-template-update.js",
       "3.0/background/clone-step-handler.js",
       "3.0/background/edit-step-as-json-handler.js",
+      "3.0/background/template-loader.js",
       "metrics.js",
       "mixpanel.js",
       "nanoajax.min.js"],
     "persistent": false
   },
+  "web_accessible_resources": [
+    "templates/*.html"
+  ],
 
   "content_security_policy": "script-src 'self' https://cdn.mxpnl.com; object-src 'self'",
 

--- a/src/octopygmy.js
+++ b/src/octopygmy.js
@@ -12,7 +12,8 @@ var octopygmy = (function() {
 			informationLogging: null,
 			updateAllTemplate: true,
 			cloneStep: true,
-			editStepAsJson: true
+			editStepAsJson: true,
+			viewReleaseDeploymentProcess: true,
 		};
 
 		chrome.storage.sync.get(defaultOptions, function(options) {

--- a/src/options.html
+++ b/src/options.html
@@ -59,6 +59,11 @@
 			<h4 class="list-group-item-heading"><input type="checkbox" id="edit-step-as-json"> Edit Step as JSON</h4>
 			<p class="list-group-item-text">Allows you to see and edit the raw JSON of a step (advanced).</p>
 		</div>
+
+		<div class="list-group-item">
+			<h4 class="list-group-item-heading"><input type="checkbox" id="view-release-deployment-process"> View release deployment process</h4>
+			<p class="list-group-item-text">Allows you to see the deployment process for an old release.</p>
+		</div>
 		
 		<div class="list-group-item">
 			<h4 class="list-group-item-heading">Logging</h4>

--- a/src/options.js
+++ b/src/options.js
@@ -16,6 +16,7 @@ function save_options() {
 	options.updateAllTemplate = document.getElementById('update-all-template').checked;
 	options.cloneStep = document.getElementById('clone-step').checked;
 	options.editStepAsJson = document.getElementById('edit-step-as-json').checked;
+	options.viewReleaseDeploymentProcess = document.getElementById('view-release-deployment-process').checked;
 
 	console.debug("Options to save:");
 	console.debug(options);
@@ -46,7 +47,8 @@ function restore_options() {
 		informationLogging: true,
 		updateAllTemplate: true,
 		cloneStep: true,
-		editStepAsJson: true
+		editStepAsJson: true,
+		viewReleaseDeploymentProcess: true,
 	};
 
 	chrome.storage.sync.get(defaults, function(options) {
@@ -64,6 +66,7 @@ function restore_options() {
 		document.getElementById('update-all-template').checked = options.updateAllTemplate;
 		document.getElementById('clone-step').checked = options.cloneStep;
 		document.getElementById('edit-step-as-json').checked = options.editStepAsJson;
+		document.getElementById('view-release-deployment-process').checked = options.viewReleaseDeploymentProcess;
 		
 		pleaForAnalytics({ srcElement: document.getElementById('analytics') });
 	});

--- a/src/templates/show-release-deployment-plan.html
+++ b/src/templates/show-release-deployment-plan.html
@@ -1,0 +1,50 @@
+<div class="modal-header">
+	<button class="close" type="button" data-dismiss="modal" aria-hidden="true" ng-hide="isWorking.busy" ng-click="close()">x</button>
+	<h3>Deployment process for release {{releaseVersion}} </h3>
+</div>
+<div class="modal-body">
+	<style>#viewReleaseDeploymentProcessContainer a { color: #333; } .col-lg-8 { width: 100%;}</style>
+	<div id="viewReleaseDeploymentProcessContainer" >
+		<project-layout suppress-create-release="deploymentProcess.Steps.length < 1">
+			<div class="row">
+				<div class="col-sm-8 col-md-8 col-lg-8">
+					<div class="form-box form-horizontal">
+						<div>
+							<div class="steps stack narrow650 margin-bottom-20">
+								<div class="stack-item" ng-class="{\'stack-link-previous\': step.StartTrigger == \'StartWithPrevious\' && !$first}" ng-repeat="step in deploymentProcess.Steps">
+									<div ng-show="step.Actions.length > 1">
+										<div class="stack-content">
+											<div class="action rolling">
+												<h4>
+												{{ $index + 1 }}. {{ step.Name }}
+												</h4>
+												<p><span ng-show=\'step.Properties["Octopus.Action.MaxParallelism"]\'>Rolling deployment</span><span ng-hide=\'step.Properties["Octopus.Action.MaxParallelism"]\'>Multi-step deployment</span> across deployment targets in roles: <tag-list tags=\'step.Properties["Octopus.Action.TargetRoles"]\'></tag-list></p>
+											</div>
+										</div>
+										<div class="stack">
+											<div class="stack-item" ng-repeat="action in step.Actions">
+												<div class="stack-content">
+												<action-summary edit-link="" number="($parent.$index + 1) + \'.\' + ($index + 1)" action="action" step="step"></action-summary>
+											</div>
+										</div>
+									</div>
+								</div>
+								<div ng-show="step.Actions.length == 1">
+									<div class="stack-content">
+									<action-summary edit-link="" number="($index + 1)" action="step.Actions[0]" step="step"></action-summary>
+								</div>
+							</div>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+	</project-layout>
+</div>
+</div>
+<div class="modal-footer">
+<spin active="isWorking.busy"></spin>
+<div>
+	<button class="btn btn-default" ng-disabled="isWorking.busy" ng-click="close()">close</button>
+</div>
+</div>


### PR DESCRIPTION
Adds the ability to view the deployment process of a release (which as you know, is a snapshot taken at the time a release is created).

At present, it just shows the high-level steps, along with step scoping as per the top level "Process" page. It doesn't allow you to drill into the steps, as this gets complicated very quickly.