### PR TITLE
Fix bug on 'view resultant variables' where scopes not always showing correctly

### DIFF
--- a/src/3.0/view-resultant-variable-list.js
+++ b/src/3.0/view-resultant-variable-list.js
@@ -55,14 +55,14 @@ pygmy3_0.viewResultantVariableList = (function() {
                     $scope.variableSetsLoading = {};
                     $scope.variables = [];
                     $scope.projectHasUnsavedChanges = unsavedChanges.hasUnsavedChanges();
-
+                    $scope.variableSetsWaitingToLoad = 0;
                     isLoading.promise(octopusRepository.Projects.get(projectId).then(function(project) {
                         $scope.projectName = project.Name;
+                        $scope.variableSetsWaitingToLoad += project.IncludedLibraryVariableSetIds.length;
                         isLoading.promise(octopusRepository.Variables.get(project.VariableSetId)).then(function(variableSet) {
-                            $scope.scopeValues = variableSet.ScopeValues;
                             _.each(variableSet.Variables, function(variable) {
                                 variable.Source = 'Project';
-                                variable.formattedScope = formatScope(variable.Id, variable.Scope, $scope.scopeValues);
+                                variable.formattedScope = formatScope(variable.Id, variable.Scope, variableSet.ScopeValues);
                             });
                             $scope.variables = $scope.variables.concat(variableSet.Variables);
                         })
@@ -74,9 +74,10 @@ pygmy3_0.viewResultantVariableList = (function() {
                                     _.each(variableSet.Variables, function(variable) {
                                         variable.Source = libraryVariableSet.Name;
                                         variable.SourceId = libraryVariableSet.Id;
-                                        variable.formattedScope = formatScope(variable.Id, variable.Scope, $scope.scopeValues);
+                                        variable.formattedScope = formatScope(variable.Id, variable.Scope, variableSet.ScopeValues);
                                     });
                                     $scope.variables = $scope.variables.concat(variableSet.Variables);
+                                    $scope.variableSetsWaitingToLoad--;
                                 })
                             })
                         })

--- a/src/templates/view-resultant-variable-list.html
+++ b/src/templates/view-resultant-variable-list.html
@@ -7,7 +7,7 @@
         Your project includes unsaved changes, which are not visible here.
     </div>
 
-    <div class="variables-snapshot">
+    <div class="variables-snapshot" ng-show="variableSetsWaitingToLoad == 0">
         <table class="table table-bordered">
             <thead>
                 <tr>


### PR DESCRIPTION
Fixes a race condition where `$scope.scopeValues` was being set when
the response from getting the project variableset was processed, but
used when processing the response from getting each included
variableset - the first call (to get project variables) may not have
responded yet.

Async is hard.