### PR TITLE
Fix table overflow issue on view resultant variables

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -1,3 +1,11 @@
 .grouping-chooser {
 	margin-left: 10px;
 }
+
+.fixed-table-width {
+	table-layout: fixed;
+}
+
+.force-word-wrap {
+	word-wrap: break-word
+}

--- a/src/templates/view-resultant-variable-list.html
+++ b/src/templates/view-resultant-variable-list.html
@@ -6,7 +6,7 @@
     <div ng-show="projectHasUnsavedChanges" class="note note-warning">
         Your project includes unsaved changes, which are not visible here.
     </div>
-
+    <loading-wrapper busy="isLoading">
     <div class="variables-snapshot" ng-show="variableSetsWaitingToLoad == 0">
         <table class="table table-bordered">
             <thead>
@@ -42,8 +42,7 @@
     </div>
 </div>
 <div class="modal-footer">
-    <spin active="isWorking.busy"></spin>
     <div>
-        <button class="btn btn-default" ng-disabled="isWorking.busy" ng-click="close()">close</button>
+        <button class="btn btn-default" ng-disabled="isLoading.busy" ng-click="close()">close</button>
     </div>
 </div>

--- a/src/templates/view-resultant-variable-list.html
+++ b/src/templates/view-resultant-variable-list.html
@@ -8,7 +8,7 @@
     </div>
     <loading-wrapper busy="isLoading">
     <div class="variables-snapshot" ng-show="variableSetsWaitingToLoad == 0">
-        <table class="table table-bordered">
+        <table class="table table-bordered fixed-table-width">
             <thead>
                 <tr>
                     <th>Name</th>
@@ -19,22 +19,21 @@
             </thead>
             <tbody class="smaller-fonts">
                 <tr ng-repeat="variable in variables | orderBy:'Name' ">
-                    <td>
-                        <div ng-class="{'limit-width': limitWidth}">{{ variable.Name }}</div>
+                    <td class="force-word-wrap">
+                        {{ variable.Name }}
                     </td>
-                    <td>
-                        <div ng-class="{'limit-width': limitWidth}"><span ng-show="variable.IsSensitive">&#x25cf;&#x25cf;&#x25cf;&#x25cf;&#x25cf;&#x25cf;&#x25cf;&#x25cf;</span>{{ variable.Value }}</div>
+                    <td class="force-word-wrap">
+                        <span ng-show="variable.IsSensitive">&#x25cf;&#x25cf;&#x25cf;&#x25cf;&#x25cf;&#x25cf;&#x25cf;&#x25cf;</span>
+                        {{ variable.Value }}
                     </td>
-                    <td>
-                        <div ng-class="{'limit-width': limitWidth}" ng-repeat="scope in variable.formattedScope">
+                    <td class="force-word-wrap">
+                        <div ng-repeat="scope in variable.formattedScope">
                             <b>{{ scope.type }}</b>: {{ scope.name }}<br/>
                         </div>
                     </td>
-                    <td>
-                         <div ng-class="{'limit-width': limitWidth}">
-                            <a ng-click="close()" ng-show="variable.SourceId" href='#/library/variables/{{ variable.SourceId }}'>{{ variable.Source }}</a>
-                            <span ng-show="!variable.SourceId">{{ variable.Source }}</span>
-                        </div>
+                    <td class="force-word-wrap">
+                        <a ng-click="close()" ng-show="variable.SourceId" href='#/library/variables/{{ variable.SourceId }}'>{{ variable.Source }}</a>
+                        <span ng-show="!variable.SourceId">{{ variable.Source }}</span>
                     </td>
                 </tr>
             </tbody>


### PR DESCRIPTION
Table was overflowing the containing modal dialog when variable names and/or variable values were wide.

Now constrains the table to the width of the dialog, and allows line breaking in the middle of words.

Also fixes the loading animation - was missing.